### PR TITLE
fix the path to yum.repos.d

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -4,5 +4,5 @@
   environment: zabbix_common_environment
 
 - name: setup zabbix repo
-  template: src=zabbix.repo.j2 dest=/etc/yum.repo.d/zabbix.repo
+  template: src=zabbix.repo.j2 dest=/etc/yum.repos.d/zabbix.repo
   environment: zabbix_common_environment


### PR DESCRIPTION
I've fixed the issue for RH/CentOS.

Currently the destination of "template" in tasks/RedHat.yml is incorrect.
User should see following error.

```
failed: [zabbixtest01] => {"failed": true}
msg: Destination directory /etc/yum.repo.d does not exist

FATAL: all hosts have already failed -- aborting
```

This pull request fix destination as "/etc/yum.repos.d".