### PR TITLE
Fix baseurl generation for RedHat

### DIFF
--- a/templates/zabbix.repo.j2
+++ b/templates/zabbix.repo.j2
@@ -1,4 +1,4 @@
 [zabbix]
 name=Zabbix.com Repository
-baseurl=http://repo.zabbix.com/zabbix/{{ ansible_architecture }}/rhel/{{ zabbix_common_config_minor_version}}/{{ ansible_lsb.major_release }}/
+baseurl=http://repo.zabbix.com/zabbix/{{ zabbix_common_config_minor_version}}/rhel/{{ ansible_lsb.major_release }}/{{ ansible_architecture }}/
 gpgcheck=1


### PR DESCRIPTION
I presume zabbix repo recently changed its layout so currently package install phase fails because yum can't find package
this PR fixes baseurl